### PR TITLE
Restructure Airtable Schema Layout

### DIFF
--- a/api-functions/datastore/Airtable.ts
+++ b/api-functions/datastore/Airtable.ts
@@ -1,5 +1,5 @@
 import Airtable from "airtable";
-import { v4 as uuidv4 } from "uuid";
+
 import {
   ApiHomeAssessmentInput,
   ApiHomeAssessmentInputWithRoomIds,
@@ -23,18 +23,18 @@ type AirtableRoomRow = {
 };
 
 type AirtableRoomResponsesRow = {
-  submissionId: string;
+  submissionId: string[];
   roomId: string;
   questionId: string;
   answer: "YES" | "NO" | "UNSURE";
 };
 
 type AirtableRoomViolationRow = {
-  id: string;
-  // Needs to be an array of strings, but typescript breaks when declared as such
-  submissionId: string;
+  submissionId: string[];
+  bylawId: string;
   roomId: string;
-} & { [bylawId: string]: string };
+  status: "violation" | "possible";
+};
 
 export class AirtableStore implements Datastore {
   private _base: ReturnType<typeof Airtable.base>;
@@ -79,13 +79,23 @@ export class AirtableStore implements Datastore {
     result: ApiHomeAssessmentResult
   ): Promise<[boolean, Error | null]> {
     try {
-      // save violations
-      await this._base("submissions_room_violations").create(
-        transformResultToViolationRows(submissionId, result).map((row) => ({
-          fields: row,
-        })),
-        { typecast: true }
-      );
+      let hasViolation = false;
+      for (const room of result.rooms) {
+        if (room.violations.length > 0 || room.possibleViolations.length > 0) {
+          hasViolation = true;
+          break;
+        }
+      }
+
+      if (hasViolation) {
+        // save violations
+        await this._base("submissions_room_violations").create(
+          transformResultToViolationRows(submissionId, result).map((row) => ({
+            fields: row,
+          })),
+          { typecast: true }
+        );
+      }
 
       return [true, null];
     } catch (error) {
@@ -97,22 +107,34 @@ export class AirtableStore implements Datastore {
 function transformResultToViolationRows(
   submissionId: string,
   result: ApiHomeAssessmentResult
-) {
-  return result.rooms.map(
-    (room): AirtableRoomViolationRow => {
-      const flattenedViolationsForRoom: { [bylawId: string]: boolean } = {};
-      for (const violation of room.violations) {
-        flattenedViolationsForRoom[violation.id] = true;
-      }
-      return {
-        id: uuidv4(),
-        // @ts-expect-error TS throws error when trying to declare the type as an array of strings
-        submissionId: [submissionId],
-        roomId: room.id,
-        ...flattenedViolationsForRoom,
-      };
+): AirtableRoomViolationRow[] {
+  const unflattenedViolations = result.rooms.map(
+    (room): AirtableRoomViolationRow[] => {
+      const violations = room.violations.map(
+        (violation): AirtableRoomViolationRow => ({
+          submissionId: [submissionId],
+          roomId: room.id,
+          bylawId: violation.id,
+          status: "violation",
+        })
+      );
+
+      const possibleViolations = room.possibleViolations.map(
+        (violation): AirtableRoomViolationRow => ({
+          submissionId: [submissionId],
+          roomId: room.id,
+          bylawId: violation.id,
+          status: "possible",
+        })
+      );
+
+      return [...violations, ...possibleViolations];
     }
   );
+
+  const emptyArray = new Array<AirtableRoomViolationRow>();
+  // flatten 2D array to 1D array
+  return emptyArray.concat(...unflattenedViolations);
 }
 
 function transformInputToRoomRows(
@@ -150,7 +172,7 @@ function transformInputToRoomResponses(
 ): AirtableRoomResponsesRow[] {
   const responsesUnflattened = input.rooms.map((room) =>
     Object.entries(room.responses).map(([questionId, response]) => ({
-      submissionId,
+      submissionId: [submissionId],
       roomId: room.id,
       questionId,
       answer: response.answer,

--- a/api-functions/handleHomeAssessment/handleHomeAssessment.test.ts
+++ b/api-functions/handleHomeAssessment/handleHomeAssessment.test.ts
@@ -21,7 +21,6 @@ const MOCK_QUESTIONS: AllRoomAssessmentQuestion = {
     {
       id: "1",
       question: "Living room Question 1",
-      type: "YES/NO",
       promptForDescriptionOn: "NO",
     },
   ],
@@ -29,7 +28,6 @@ const MOCK_QUESTIONS: AllRoomAssessmentQuestion = {
     {
       id: "2",
       question: "Washroom Question 2",
-      type: "YES/NO",
       promptForDescriptionOn: "NO",
     },
   ],
@@ -37,13 +35,11 @@ const MOCK_QUESTIONS: AllRoomAssessmentQuestion = {
     {
       id: "3",
       question: "Bedroom Question 3",
-      type: "YES/NO",
       promptForDescriptionOn: "NO",
     },
     {
       id: "4",
       question: "Bedroom Question 3",
-      type: "YES/NO",
       promptForDescriptionOn: "NO",
     },
   ],

--- a/components/home-assessment/hooks/useIsAssessmentValid.test.tsx
+++ b/components/home-assessment/hooks/useIsAssessmentValid.test.tsx
@@ -13,7 +13,6 @@ const DEFAULT_QUESTIONS: RoomAssessmentQuestions = {
     {
       id: "1",
       question: "LIVING 1",
-      type: "YES/NO",
       promptForDescriptionOn: "YES",
     },
   ],
@@ -21,7 +20,6 @@ const DEFAULT_QUESTIONS: RoomAssessmentQuestions = {
     {
       id: "2",
       question: "WASH 1",
-      type: "YES/NO",
       promptForDescriptionOn: "YES",
     },
   ],
@@ -29,7 +27,6 @@ const DEFAULT_QUESTIONS: RoomAssessmentQuestions = {
     {
       id: "3",
       question: "BED 1",
-      type: "YES/NO",
       promptForDescriptionOn: "YES",
     },
   ],

--- a/data/kingston/bylawMultiplexer.json
+++ b/data/kingston/bylawMultiplexer.json
@@ -1,9 +1,9 @@
 {
   "rules": [
-    { "bylawId": "bylaw1", "mustBeTrue": ["1"], "mustBeFalse": [] }
+    { "bylawId": "1", "mustBeTrue": ["1"], "mustBeFalse": [] }
   ],
   "bylaws": {
-    "bylaw1": {
+    "1": {
       "name": "5.9 Doors, Windows, and Skylights",
       "description": "No room shall be used for sleeping purposes unless it has a minimum area of at least 7 square metres (75 square feet), where built in cabinets/closets are not provided, and no less than 6 square meters (65 square feet) where built in cabinets/closets are provided and no less than that required by the Ontario Building Code as amended."
     }

--- a/data/kingston/questions.json
+++ b/data/kingston/questions.json
@@ -3,13 +3,11 @@
     {
       "id": "1",
       "question": "LIVING 1",
-      "type": "YES/NO",
       "promptForDescriptionOn": "NO"
     },
     {
       "id": "2",
       "question": "LIVING 2",
-      "type": "YES/NO",
       "promptForDescriptionOn": "NO"
     }
   ],
@@ -17,13 +15,11 @@
     {
       "id": "3",
       "question": "WASH 1",
-      "type": "YES/NO",
       "promptForDescriptionOn": "NO"
     },
     {
       "id": "4",
       "question": "WASH 2",
-      "type": "YES/NO",
       "promptForDescriptionOn": "NO"
     }
   ],
@@ -31,13 +27,11 @@
     {
       "id": "5",
       "question": "BED 1",
-      "type": "YES/NO",
       "promptForDescriptionOn": "NO"
     },
     {
       "id": "6",
       "question": "BED 2",
-      "type": "YES/NO",
       "promptForDescriptionOn": "NO"
     }
   ]

--- a/interfaces/home-assessment.ts
+++ b/interfaces/home-assessment.ts
@@ -1,7 +1,6 @@
 export type RoomAssessmentQuestion = {
   id: string;
   question: string;
-  type: "YES/NO";
   promptForDescriptionOn: "YES" | "NO";
 };
 


### PR DESCRIPTION
Adjust the schema's for the violations and responses table to scale vertically rather then horizontally (in terms of schema).